### PR TITLE
SOR-3845: Allow setting keys instead of generated UUIDs

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,7 +6,7 @@ rate_limiter:
   enabled: true
   num_requests: 100
 request_limits:
-  allow_setting_keys: false
+  allow_setting_keys: true
   max_size_bytes: 10240 # 10K
   max_num_values: 10
   max_ttl_seconds: 3600


### PR DESCRIPTION
Cactus is using keys to push VAST tags to prebid-cache for Sponsored video ads. 