### PR TITLE
Direct Browsers to use http cache to cache data

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,7 @@ func setConfigDefaults(v *viper.Viper) {
 	v.SetDefault("request_limits.max_size_bytes", 10*1024)
 	v.SetDefault("request_limits.max_num_values", 10)
 	v.SetDefault("request_limits.max_ttl_seconds", 3600)
+	v.SetDefault("response_caching.ttl_seconds", 60)
 	v.SetDefault("metrics.graphite.host", "")
 	v.SetDefault("metrics.graphite.prefix", "")
 	v.SetDefault("metrics.graphite.interval_sec", 10)
@@ -50,14 +51,15 @@ func setEnvVars(v *viper.Viper) {
 }
 
 type Configuration struct {
-	Port          int           `mapstructure:"port"`
-	AdminPort     int           `mapstructure:"admin_port"`
-	Log           Log           `mapstructure:"log"`
-	RateLimiting  RateLimiting  `mapstructure:"rate_limiter"`
-	RequestLimits RequestLimits `mapstructure:"request_limits"`
-	Backend       Backend       `mapstructure:"backend"`
-	Compression   Compression   `mapstructure:"compression"`
-	Metrics       Metrics       `mapstructure:"metrics"`
+	Port            int             `mapstructure:"port"`
+	AdminPort       int             `mapstructure:"admin_port"`
+	Log             Log             `mapstructure:"log"`
+	RateLimiting    RateLimiting    `mapstructure:"rate_limiter"`
+	RequestLimits   RequestLimits   `mapstructure:"request_limits"`
+	ResponseCaching ResponseCaching `mapstructure:"response_caching"`
+	Backend         Backend         `mapstructure:"backend"`
+	Compression     Compression     `mapstructure:"compression"`
+	Metrics         Metrics         `mapstructure:"metrics"`
 }
 
 // ValidateAndLog validates the config, terminating the program on any errors.
@@ -68,6 +70,7 @@ func (cfg *Configuration) ValidateAndLog() {
 	cfg.Log.validateAndLog()
 	cfg.RateLimiting.validateAndLog()
 	cfg.RequestLimits.validateAndLog()
+	cfg.ResponseCaching.validateAndLog()
 	cfg.Backend.validateAndLog()
 	cfg.Compression.validateAndLog()
 	cfg.Metrics.validateAndLog()
@@ -114,6 +117,14 @@ func (cfg *RequestLimits) validateAndLog() {
 	log.Infof("config.request_limits.max_ttl_seconds: %d", cfg.MaxTTLSeconds)
 	log.Infof("config.request_limits.max_size_bytes: %d", cfg.MaxSize)
 	log.Infof("config.request_limits.max_num_values: %d", cfg.MaxNumValues)
+}
+
+type ResponseCaching struct {
+	TTLSeconds int `mapstructure:"ttl_seconds"`
+}
+
+func (cfg *ResponseCaching) validateAndLog() {
+	log.Infof("config.response_caching.ttl_seconds: %v", cfg.TTLSeconds)
 }
 
 type Compression struct {

--- a/endpoints/integration_test.go
+++ b/endpoints/integration_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/prebid/prebid-cache/backends"
 )
 
+const mockHTTPCacheTTL = 60
+
 func doMockGet(t *testing.T, router *httprouter.Router, id string) *httptest.ResponseRecorder {
 	requestRecorder := httptest.NewRecorder()
 
@@ -58,7 +60,7 @@ func expectStored(t *testing.T, putBody string, expectedGet string, expectedMime
 	backend := backends.NewMemoryBackend()
 
 	router.POST("/cache", NewPutHandler(backend, 10, true))
-	router.GET("/cache", NewGetHandler(backend, true))
+	router.GET("/cache", NewGetHandler(backend, true, mockHTTPCacheTTL))
 
 	uuid, putTrace := doMockPut(t, router, putBody)
 	if putTrace.Code != http.StatusOK {
@@ -169,7 +171,7 @@ func TestXMLOther(t *testing.T) {
 func TestGetInvalidUUIDs(t *testing.T) {
 	backend := backends.NewMemoryBackend()
 	router := httprouter.New()
-	router.GET("/cache", NewGetHandler(backend, false))
+	router.GET("/cache", NewGetHandler(backend, false, mockHTTPCacheTTL))
 
 	getResults := doMockGet(t, router, "fdd9405b-ef2b-46da-a55a-2f526d338e16")
 	if getResults.Code != http.StatusNotFound {

--- a/endpoints/routing/handler.go
+++ b/endpoints/routing/handler.go
@@ -20,7 +20,7 @@ func NewHandler(cfg config.Configuration, dataStore backends.Backend, appMetrics
 	router.GET("/", endpoints.Index)        //Default route handler
 	router.GET("/status", endpoints.Status) // Determines whether the server is ready for more traffic.
 	router.POST("/cache", decorators.MonitorHttp(endpoints.NewPutHandler(dataStore, cfg.RequestLimits.MaxNumValues, cfg.RequestLimits.AllowSettingKeys), appMetrics.Puts))
-	router.GET("/cache", decorators.MonitorHttp(endpoints.NewGetHandler(dataStore, cfg.RequestLimits.AllowSettingKeys), appMetrics.Gets))
+	router.GET("/cache", decorators.MonitorHttp(endpoints.NewGetHandler(dataStore, cfg.RequestLimits.AllowSettingKeys, cfg.ResponseCaching.TTLSeconds), appMetrics.Gets))
 
 	handler := handleCors(router)
 	handler = handleRateLimiting(handler, cfg.RateLimiting)


### PR DESCRIPTION
* Direct client to utilize HTTP cache for caching data, so that the
  ad can load from local cache if requested in quick succession