### PR TITLE
SOR-4262: Increase Prebid Cache Max Payload Size

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,7 +7,7 @@ rate_limiter:
   num_requests: 100
 request_limits:
   allow_setting_keys: true
-  max_size_bytes: 10240 # 10K
+  max_size_bytes: 20480 # 20 KiB
   max_num_values: 10
   max_ttl_seconds: 3600
 backend:


### PR DESCRIPTION
* Increase the max size payload that Prebid Cache can hold because
  SpotX is returning payloads that are about 13 KiB and the limit
  is currently 10 KiB